### PR TITLE
Release/1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can call the following methods on the BladeOne Module to configure the Blade
 * [template_path](docs/BladeOne-Module.md#public-function-template_path-string-template_path-)
 * [compiled_path](docs/BladeOne-Module.md#public-function-compiled_path-string-compiled_path-)
 * [mode](docs/BladeOne-Module.md#public-function-mode-int-mode-)
-* [comment_mode](docs/BladeOne-Module.md#public-function-comment_mode-int-comment_mode-)
+* [comment_mode](docs/BladeOne-Module.md#public-function-comment_mode-int-mode)
 * [config](docs/BladeOne-Module.md#public-function-configcallable-config)
 
 ## BladeOne_Engine Config

--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ $app = ( new App_Factory('path/to/project/root') )
          ->template_path('path/to/custom/views')
          ->compiled_path('path/to/custom/cache'); // Fluent API for chaining.
       
-      $blade->mode( BladeOne::MODE_DEBUG );
+      // Set the rendering mode.
+      $blade->mode(  PinkCrab_BladeOne::MODE_DEBUG );
+
+      // Set the comment mode.
+      $blade->comment_mode( PinkCrab_BladeOne::COMMENT_RAW );
 
       // BladeOne_Engine config.
       $blade->config( function( BladeOne_Engine $engine  {
@@ -132,7 +136,8 @@ $app = ( new App_Factory('path/to/project/root') )
    ->module(BladeOne::class, fn( BladeOne $blade ) => $blade
       ->template_path('path/to/custom/views')
       ->compiled_path('path/to/custom/cache')
-      ->mode( BladeOne::MODE_DEBUG )
+      ->mode(  PinkCrab_BladeOne::MODE_DEBUG )
+      ->comment_mode( PinkCrab_BladeOne::COMMENT_RAW )
       ->config( fn( BladeOne_Engine $engine ) => $engine
          ->set_compiled_extension('.php')
          ->directive('test', fn($e) =>'test')
@@ -166,6 +171,7 @@ You can call the following methods on the BladeOne Module to configure the Blade
 * [template_path](docs/BladeOne-Module.md#public-function-template_path-string-template_path-)
 * [compiled_path](docs/BladeOne-Module.md#public-function-compiled_path-string-compiled_path-)
 * [mode](docs/BladeOne-Module.md#public-function-mode-int-mode-)
+* [comment_mode](docs/BladeOne-Module.md#public-function-comment_mode-int-comment_mode-)
 * [config](docs/BladeOne-Module.md#public-function-configcallable-config)
 
 ## BladeOne_Engine Config

--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ http://www.opensource.org/licenses/mit-license.html
 * For support of all versions before Perique V2, please use the [BladeOne_Provider](https://github.com/Pink-Crab/Perique-BladeOne-Provider)
 
 ## Change Log ##
+* 1.1.0 - Provides BladeOne 4.12+ and BladeOneHTML 2.4+. With comment mode support.
 * 1.0.1 - Last version to support pre 4.12 BladeOne (will be the last)
 * 1.0.0 - Migrated over from the Perique V2 Prep branch of BladeOne_Provider.
   * New Features

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,8 @@
     "require": {
         "php": ">=7.4.0",
         "pinkcrab/perique-framework-core": "2.0.*",
-        "eftec/bladeone": "<=4.11",
-        "eftec/bladeonehtml": "<=2.3.2",
+        "eftec/bladeone": ">=4.12",
+        "eftec/bladeonehtml": ">=2.4",
         "pinkcrab/function-constructors": "0.2.*"
     },
     "scripts": {

--- a/docs/BladeOne-Module.md
+++ b/docs/BladeOne-Module.md
@@ -59,7 +59,7 @@ Allows the setting of the mode, this will be used for all templates run through 
 
 *****
 ### **public function comment_mode( int $mode)**
-> @param int $mode
+> @param int $mode  
 > @return self
 
 Allows the setting of the comment mode, this will be used for all templates run through BladeOne.

--- a/docs/BladeOne-Module.md
+++ b/docs/BladeOne-Module.md
@@ -57,6 +57,18 @@ Allows the setting of the mode, this will be used for all templates run through 
 * **PinkCrab_BladeOne::MODE_SLOW** - Slow mode, the compiled templates will be cached, but the cache will be checked on every request.
 * **PinkCrab_BladeOne::MODE_FAST** - Fast mode, the compiled templates will be cached, and the cache will only be checked if the original template has been modified.
 
+*****
+### **public function comment_mode( int $mode)**
+> @param int $mode
+> @return self
+
+Allows the setting of the comment mode, this will be used for all templates run through BladeOne.
+
+**Modes:**
+* **PinkCrab_BladeOne::COMMENT_PHP** - PHP comments will be used.
+* **PinkCrab_BladeOne::COMMENT_RAW** - HTML comments will be used.
+* **PinkCrab_BladeOne::COMMENT_NONE** - No comments will be used.
+
 ****
 ### **public function config(\callable $config)**
 > @param callable(BladeOne_Engine $engine) $config  

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,3 +12,5 @@ parameters:
         - vendor/php-stubs/wordpress-stubs/wordpress-stubs.php
     ignoreErrors:
         - '#Parameter \#2 \$role of method eftec\\bladeone\\BladeOne::setAuth\(\) expects null, string given#'
+        - '#Parameter \#1 \$templatePath of method eftec\\bladeone\\BladeOne::__construct\(\) expects null#'
+        - '#Parameter \#2 \$compiledPath of method eftec\\bladeone\\BladeOne::__construct\(\) expects null#'

--- a/src/BladeOne.php
+++ b/src/BladeOne.php
@@ -41,7 +41,8 @@ class BladeOne implements Module {
 	private ?string $template_path = null;
 	private ?string $compiled_path = null;
 
-	private int $mode = PinkCrab_BladeOne::MODE_AUTO;
+	private int $mode         = PinkCrab_BladeOne::MODE_AUTO;
+	private int $comment_mode = PinkCrab_BladeOne::COMMENT_PHP;
 
 	/**
 	 * Holds the config closure.
@@ -80,6 +81,17 @@ class BladeOne implements Module {
 	 */
 	public function mode( int $mode ): self {
 		$this->mode = $mode;
+		return $this;
+	}
+
+	/**
+	 * Set the comment mode.
+	 *
+	 * @param integer $comment_mode
+	 * @return self
+	 */
+	public function comment_mode( int $comment_mode ): self {
+		$this->comment_mode = $comment_mode;
 		return $this;
 	}
 
@@ -125,7 +137,8 @@ class BladeOne implements Module {
 		$instance      = new PinkCrab_BladeOne(
 			$this->template_path ?? $config->path( 'view' ),
 			$compiled_path,
-			$this->mode
+			$this->mode,
+			$this->comment_mode
 		);
 
 		$instance->setAuth( ...$this->get_auth_data() );

--- a/src/BladeOne_Engine.php
+++ b/src/BladeOne_Engine.php
@@ -309,6 +309,17 @@ class BladeOne_Engine implements Renderable {
 	}
 
 	/**
+	 * Set the comment mode
+	 *
+	 * @param integer $comment_mode BladeOne::COMMENT_PHP, BladeOne::COMMENT_RAW, BladeOne::COMMENT_NONE
+	 * @return self
+	 */
+	public function set_comment_mode( int $comment_mode ): self {
+		static::$blade->setCommentMode( $comment_mode );
+		return $this;
+	}
+
+	/**
 	 * Adds a global variable. If <b>$var_name</b> is an array then it merges all the values.
 	 * <b>Example:</b>
 	 * <pre>

--- a/src/PinkCrab_BladeOne.php
+++ b/src/PinkCrab_BladeOne.php
@@ -26,6 +26,7 @@ declare( strict_types=1 );
 
 namespace PinkCrab\BladeOne;
 
+use COM;
 use eftec\bladeone\BladeOne;
 use eftec\bladeonehtml\BladeOneHtml;
 use PinkCrab\Perique\Application\App;
@@ -41,6 +42,10 @@ class PinkCrab_BladeOne extends BladeOne {
 
 	public const SETUP_CONFIG = 'PinkCrab/BladeOne_Engine/Setup_Config';
 
+	public const COMMENT_PHP  = 0;
+	public const COMMENT_RAW  = 1;
+	public const COMMENT_NONE = 2;
+
 	/**
 	 * Bob the constructor.
 	 * The folder at $compiled_path is created in case it doesn't exist.
@@ -48,9 +53,10 @@ class PinkCrab_BladeOne extends BladeOne {
 	 * @param string|string[] $template_path If null then it uses (caller_folder)/views
 	 * @param string          $compiled_path If null then it uses (caller_folder)/compiles
 	 * @param integer         $mode          =[BladeOne::MODE_AUTO,BladeOne::MODE_DEBUG,BladeOne::MODE_FAST,BladeOne::MODE_SLOW][$i]
+	 * @param integer         $comment_mode  =[BladeOne::COMMENT_PHP,BladeOne::COMMENT_RAW,BladeOne::COMMENT_NONE][$i]
 	 */
-	public function __construct( $template_path = null, $compiled_path = null, $mode = 0 ) {
-		parent::__construct( $template_path, $compiled_path, $mode );
+	public function __construct( $template_path = null, $compiled_path = null, $mode = 0, $comment_mode = 0 ) {
+		parent::__construct( $template_path, $compiled_path, $mode, $comment_mode );
 
 		// Add the viewModel directive.
 		$this->directiveRT( 'viewModel', fn( $expression ) => $this->view_model( $expression, true ) );
@@ -87,7 +93,7 @@ class PinkCrab_BladeOne extends BladeOne {
 	 *
 	 * @var string
 	 */
-	protected $echoFormat = '\esc_html(%s)'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
+	protected string $echoFormat = '\esc_html(%s)'; //phpcs:ignore WordPress.NamingConventions.ValidVariableName.PropertyNotSnakeCase
 
 
 	/**
@@ -235,5 +241,14 @@ class PinkCrab_BladeOne extends BladeOne {
 		}
 
 		return $this->phpTag . "elseif(PinkCrab\FunctionConstructors\Strings\isBlank(\$this->currentUser) || \$this->currentRole!=$role): ?>";
+	}
+
+	/**
+	 * Get the comment mode.
+	 *
+	 * @return integer
+	 */
+	public function getCommentMode(): int {
+		return $this->commentMode;
 	}
 }

--- a/tests/Application/Test_As_Application.php
+++ b/tests/Application/Test_As_Application.php
@@ -41,7 +41,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 	}
 
-	/** @testdox It should be possible to render a template using only its filename and pass values to the view to be rendered */
+	/**
+ * @testdox It should be possible to render a template using only its filename and pass values to the view to be rendered
+*/
 	public function test_render_template_using_only_file_name() {
 		$app = $this->pre_populated_app_provider();
 
@@ -49,13 +51,15 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertEquals( 'bar', $output );
 	}
 
-	/** @testdox It should be possible to set a custom template path when adding BladeOne as a module */
+	/**
+ * @testdox It should be possible to set a custom template path when adding BladeOne as a module
+*/
 	public function test_set_custom_template_path() {
 		$app = ( new App_Factory( \FIXTURES_PATH ) )
 			->default_setup()
 			->module(
 				BladeOne_Module::class,
-				function( BladeOne_Module $e ) {
+				function ( BladeOne_Module $e ) {
 					$e->template_path( \FIXTURES_PATH . 'views/custom-path' );
 					$e->compiled_path( \FIXTURES_PATH . 'cache' );
 					return $e;
@@ -68,13 +72,15 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertEquals( 'bar', $output );
 	}
 
-	/** @testdox It should be possible to configure the template and compiled paths, mode and access the BladeOne_Engine from the Modules config callback. */
+	/**
+ * @testdox It should be possible to configure the template and compiled paths, mode and access the BladeOne_Engine from the Modules config callback.
+*/
 	public function test_configure_bladeone_module() {
 
 		// Test the config action.
 		add_action(
 			PinkCrab_BladeOne::SETUP_CONFIG,
-			function( PinkCrab_BladeOne $blade_instance ) {
+			function ( PinkCrab_BladeOne $blade_instance ) {
 				$this->assertEquals( BladeOne::MODE_DEBUG, $blade_instance->getMode() );
 			}
 		);
@@ -83,15 +89,16 @@ class Test_As_Application extends WP_UnitTestCase {
 			->default_setup()
 			->module(
 				BladeOne_Module::class,
-				function( BladeOne_Module $e ) {
+				function ( BladeOne_Module $e ) {
 					$e->template_path( \FIXTURES_PATH . 'views/custom-path' );
 					$e->compiled_path( \FIXTURES_PATH . 'cache' );
 					$e->mode( BladeOne::MODE_DEBUG );
+					$e->comment_mode( PinkCrab_BladeOne::COMMENT_PHP );
 					$e->config(
-						function( BladeOne_Engine $engine ) {
+						function ( BladeOne_Engine $engine ) {
 							$engine->directive(
 								'bar',
-								function( $expression ) {
+								function ( $expression ) {
 									return "<?php echo 'barf'; ?>";
 								}
 							);
@@ -108,6 +115,7 @@ class Test_As_Application extends WP_UnitTestCase {
 
 		// Check mode is debug.
 		$this->assertEquals( BladeOne::MODE_DEBUG, $blade->getMode() );
+		$this->assertEquals( PinkCrab_BladeOne::COMMENT_PHP, $blade->getCommentMode() );
 
 		// Check the custom directive is added.
 		$this->assertEquals(
@@ -117,7 +125,7 @@ class Test_As_Application extends WP_UnitTestCase {
 
 		// Check that both paths are set.
 		$health_check = Output::buffer(
-			function() use ( $blade ) {
+			function () use ( $blade ) {
 				$result = $blade->checkHealthPath();
 				$this->assertTrue( $result );
 			}
@@ -127,7 +135,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertStringContainsString( \sprintf( 'Template-path (view) [%s] is a folder ', \FIXTURES_PATH . 'views/custom-path' ), $health_check );
 	}
 
-	/** @testdox It should be possible to define a compiled path and have it created if it doesnt exist. */
+	/**
+ * @testdox It should be possible to define a compiled path and have it created if it doesnt exist.
+*/
 	public function test_create_compiled_path_if_not_exists() {
 		$this->unset_app_instance();
 
@@ -137,7 +147,7 @@ class Test_As_Application extends WP_UnitTestCase {
 			->default_setup()
 			->module(
 				BladeOne_Module::class,
-				function( BladeOne_Module $e ) use ( $cached_path ) {
+				function ( BladeOne_Module $e ) use ( $cached_path ) {
 					return $e
 						->template_path( \FIXTURES_PATH . 'views/custom-path' )
 						->compiled_path( $cached_path );
@@ -149,7 +159,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertTrue( \file_exists( $cached_path ) );
 	}
 
-	/** @testdox It should be possible to render a component nested inside another component */
+	/**
+ * @testdox It should be possible to render a component nested inside another component
+*/
 	public function test_can_render_nested_component(): void {
 		$app = $this->pre_populated_app_provider();
 
@@ -161,7 +173,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		);
 	}
 
-	/** @testdox It should be possible to render an nested view model using $this->view_model($instance) */
+	/**
+ * @testdox It should be possible to render an nested view model using $this->view_model($instance)
+*/
 	public function test_can_render_nested_view_model(): void {
 		$app = $this->pre_populated_app_provider();
 
@@ -170,14 +184,16 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'woo', $value );
 	}
 
-	/** @testdox When a string is escaped, it should use the default WP esc_html */
+	/**
+ * @testdox When a string is escaped, it should use the default WP esc_html
+*/
 	public function test_can_escape_string(): void {
 		$app = $this->pre_populated_app_provider();
 
 		$called_esc_html = false;
 		add_filter(
 			'esc_html',
-			function( $value ) use ( &$called_esc_html ) {
+			function ( $value ) use ( &$called_esc_html ) {
 				$called_esc_html = true;
 				return $value;
 			}
@@ -187,14 +203,16 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertTrue( $called_esc_html );
 	}
 
-	/** @testdox It should be possible to set any function as the esc function */
+	/**
+ * @testdox It should be possible to set any function as the esc function
+*/
 	public function test_set_custom_esc_function(): void {
 		$app = $this->pre_populated_app_provider();
 
 		$called_esc_html = false;
 		add_filter(
 			'attribute_escape',
-			function( $value ) use ( &$called_esc_html ) {
+			function ( $value ) use ( &$called_esc_html ) {
 				$called_esc_html = true;
 				return $value;
 			}
@@ -205,7 +223,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertTrue( $called_esc_html );
 	}
 
-	/** @testdox It should be possible to render an nested view model using @viewModel($instance) */
+	/**
+ * @testdox It should be possible to render an nested view model using @viewModel($instance)
+*/
 	public function test_can_render_nested_view_model_directive(): void {
 		$app = $this->pre_populated_app_provider();
 
@@ -214,7 +234,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'woo', $value );
 	}
 
-	/** @testdox It should be possible to render a component nested inside another component using @component($instance) */
+	/**
+ * @testdox It should be possible to render a component nested inside another component using @component($instance)
+*/
 	public function test_can_render_nested_component_using_directive(): void {
 		$app = $this->pre_populated_app_provider();
 
@@ -250,7 +272,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertEquals( $path, Objects::get_property( $blade, 'compiledPath' ) );
 	}
 
-	/** @testdox It should be possible to get the details of a logged in user */
+	/**
+ * @testdox It should be possible to get the details of a logged in user
+*/
 	public function test_can_get_user_details(): void {
 		$user = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user->ID );
@@ -275,10 +299,11 @@ class Test_As_Application extends WP_UnitTestCase {
 		foreach ( $user->allcaps as $cap => $value ) {
 			$this->assertContains( $cap, $current_permissions );
 		}
-
 	}
 
-	/** @testdox When no user is logged in, this should be reflected in blades auth data. */
+	/**
+ * @testdox When no user is logged in, this should be reflected in blades auth data.
+*/
 	public function test_can_get_user_details_when_no_user_logged_in(): void {
 		wp_set_current_user( 0 );
 		$app = $this->pre_populated_app_provider();
@@ -297,7 +322,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertEmpty( $current_permissions );
 	}
 
-	/** @testdox It should be possible to use WP user roles to make some aspects of the template render logged in as administrator*/
+	/**
+ * @testdox It should be possible to use WP user roles to make some aspects of the template render logged in as administrator
+*/
 	public function test_user_auth_logged_in_rendered_admin(): void {
 		$user = $this->factory()->user->create_and_get( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user->ID );
@@ -318,7 +345,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'can_manage_options', $output );
 	}
 
-	/** @testdox It should be possible to use WP user roles to make some aspects of the template render logged in as edior*/
+	/**
+ * @testdox It should be possible to use WP user roles to make some aspects of the template render logged in as edior
+*/
 	public function test_user_auth_logged_in_rendered_editor(): void {
 		$user = $this->factory()->user->create_and_get( array( 'role' => 'editor' ) );
 		wp_set_current_user( $user->ID );
@@ -339,7 +368,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'can_edit_posts', $output );
 	}
 
-	/** @testdox It should be possible to use WP user roles to make some aspects of the template render */
+	/**
+ * @testdox It should be possible to use WP user roles to make some aspects of the template render
+*/
 	public function test_user_auth_logged_out_rendered(): void {
 		wp_set_current_user( 0 );
 
@@ -382,7 +413,9 @@ class Test_As_Application extends WP_UnitTestCase {
 		}
 	}
 
-	/** DataProvider for test_can_add_nonce_to_template */
+	/**
+ * DataProvider for test_can_add_nonce_to_template
+*/
 	public function nonce_provider(): array {
 		return array(
 			array( 'with_ref_nonce', 'with_referer', true ),
@@ -390,6 +423,4 @@ class Test_As_Application extends WP_UnitTestCase {
 			array( 'def_ref_nonce', '_pcnonce', true ),
 		);
 	}
-
-
 }

--- a/tests/Unit/Test_BladeOne_Engine.php
+++ b/tests/Unit/Test_BladeOne_Engine.php
@@ -18,6 +18,7 @@ use BadMethodCallException;
 use eftec\bladeone\BladeOne;
 use Gin0115\WPUnit_Helpers\Objects;
 use PinkCrab\BladeOne\BladeOne_Engine;
+use PinkCrab\BladeOne\PinkCrab_BladeOne;
 use PinkCrab\Perique\Services\View\View;
 use PinkCrab\BladeOne\Tests\Fixtures\Input;
 use PinkCrab\Perique\Services\View\View_Model;
@@ -239,6 +240,19 @@ class Test_BladeOne_Engine extends WP_UnitTestCase {
 
 		$provider->set_mode( BladeOne::MODE_SLOW );
 		$this->assertEquals( 1, $provider->get_blade()->getMode() );
+	}
+
+	/** @testdox It should be possible to set the comment mode blade uses when rendering */
+	public function test_set_comment_mode(): void {
+		$provider = $this->get_engine();
+		$provider->set_comment_mode( PinkCrab_BladeOne::COMMENT_PHP );
+		$this->assertEquals( 0, $provider->get_blade()->getCommentMode() );
+
+		$provider->set_comment_mode( PinkCrab_BladeOne::COMMENT_RAW );
+		$this->assertEquals( 1, $provider->get_blade()->getCommentMode() );
+
+		$provider->set_comment_mode( PinkCrab_BladeOne::COMMENT_NONE );
+		$this->assertEquals( 2, $provider->get_blade()->getCommentMode() );
 	}
 
 	/** @testdox It should be possible to share a value globally between al templates. */


### PR DESCRIPTION
This pull request introduces a new feature to support comment modes in the BladeOne templating engine and updates the package dependencies. The most important changes include adding the comment mode feature, updating the documentation, and modifying test cases to reflect the new feature.

### New Features:

* Added support for comment modes in BladeOne, including `COMMENT_PHP`, `COMMENT_RAW`, and `COMMENT_NONE`. (`src/BladeOne.php`, `src/PinkCrab_BladeOne.php`, `src/BladeOne_Engine.php`) [[1]](diffhunk://#diff-33203c3f393e648bd3ea82bff135bbf0d0a64115518145410f1c204678728437R45) [[2]](diffhunk://#diff-bb762da3cbf07d055d3c0870f185a7440ad3f86af9b7e00bfe39bb9d236f29d0R45-R59) [[3]](diffhunk://#diff-f4a42325d4d848a58d135925a2c647e6e9cdbfc6434130f80db852afff4c8db8R311-R321)
* Updated `README.md` to include information about the new comment mode feature. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L106-R110) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L135-R140) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R174)

### Documentation Updates:

* Added a new section in `docs/BladeOne-Module.md` to document the `comment_mode` method and its usage.

### Dependency Updates:

* Updated `composer.json` to require newer versions of `eftec/bladeone` and `eftec/bladeonehtml`. (`composer.json`)

### Test Case Modifications:

* Modified test cases in `tests/Application/Test_As_Application.php` to include tests for the new comment mode feature. (F82dcd3cL43R43, [[1]](diffhunk://#diff-9054727cc819695d2c6f2dfe79c28c4a9adafc555c9f49f5de56b01e82285a1cL71-R77) [[2]](diffhunk://#diff-9054727cc819695d2c6f2dfe79c28c4a9adafc555c9f49f5de56b01e82285a1cR96)