### PR TITLE
Bumped to later version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,23 +26,23 @@
         "gin0115/wpunit-helpers": "1.1.*",
         "wp-cli/i18n-command": "*",
         "squizlabs/php_codesniffer": "3.*",
-        "dealerdirect/phpcodesniffer-composer-installer": "*",
         "roave/security-advisories": "dev-latest",
-        "php-stubs/wordpress-stubs": "6.5.*",
         "phpunit/phpunit": "^8.5 || ^9.0",
-        "roots/wordpress": "6.5.*",
-        "wp-phpunit/wp-phpunit": "6.5.*",
         "yoast/phpunit-polyfills": "^1.0.0 || ^2.0.0",
         "vlucas/phpdotenv": "<=5.5.0",
-        "wp-coding-standards/wpcs": "^3",
         "phpcompatibility/phpcompatibility-wp": "*",
         "phpstan/phpstan": "1.*",
         "szepeviktor/phpstan-wordpress": "<=1.3.1",
-        "symfony/var-dumper": "^5.0"
+        "php-stubs/wordpress-stubs": "6.6.*",
+        "roots/wordpress": "6.6.*",
+        "wp-phpunit/wp-phpunit": "6.6.*",
+        "dealerdirect/phpcodesniffer-composer-installer": "*",
+        "wp-coding-standards/wpcs": "^3",
+        "symfony/var-dumper": "<=6.2.7"
     },
     "require": {
         "php": ">=7.4.0",
-        "pinkcrab/perique-framework-core": "2.0.*",
+        "pinkcrab/perique-framework-core": "2.1.*",
         "eftec/bladeone": ">=4.12",
         "eftec/bladeonehtml": ">=2.4",
         "pinkcrab/function-constructors": "0.2.*"
@@ -51,6 +51,7 @@
         "test": "vendor/bin/phpunit --colors=always --testdox --coverage-clover clover.xml",
         "coverage": "vendor/bin/phpunit --colors=always --testdox --coverage-html coverage-report",
         "analyse": "vendor/bin/phpstan analyse src -l8",
+        "format": "./vendor/bin/phpcbf src -v",
         "sniff": "./vendor/bin/phpcs src/ -v",
         "all": "composer coverage && composer analyse && composer sniff"
     },

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -4,6 +4,7 @@ includes:
 parameters:
     level: max
     inferPrivatePropertyTypeFromConstructor: true
+    reportUnmatchedIgnoredErrors: false
     paths:
         - %currentWorkingDirectory%/src/
     excludePaths:

--- a/src/BladeOne.php
+++ b/src/BladeOne.php
@@ -135,7 +135,7 @@ class BladeOne implements Module {
 		$wp_upload_dir = wp_upload_dir();
 		$compiled_path = $this->compiled_path ?? sprintf( '%1$s%2$sblade-cache', $wp_upload_dir['basedir'], \DIRECTORY_SEPARATOR ); // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundInImplementedInterfaceBeforeLastUsed
 		$instance      = new PinkCrab_BladeOne(
-			$this->template_path ?? $config->path( 'view' ),
+			$this->template_path ?? $config->view_path(),
 			$compiled_path,
 			$this->mode,
 			$this->comment_mode

--- a/src/BladeOne_Engine.php
+++ b/src/BladeOne_Engine.php
@@ -66,9 +66,9 @@ class BladeOne_Engine implements Renderable {
 	/**
 	 * Static constructor with BladeOne initialisation details
 	 *
-	 * @param string|array<mixed> $template_path If null then it uses (caller_folder)/views
-	 * @param string              $compiled_path If null then it uses (caller_folder)/compiles
-	 * @param integer             $mode          =[BladeOne::MODE_AUTO,BladeOne::MODE_DEBUG,BladeOne::MODE_FAST,BladeOne::MODE_SLOW][$i]
+	 * @param string  $template_path If null then it uses (caller_folder)/views
+	 * @param string  $compiled_path If null then it uses (caller_folder)/compiles
+	 * @param integer $mode          =[BladeOne::MODE_AUTO,BladeOne::MODE_DEBUG,BladeOne::MODE_FAST,BladeOne::MODE_SLOW][$i]
 	 * @return self
 	 */
 	public static function init(

--- a/src/PinkCrab_BladeOne.php
+++ b/src/PinkCrab_BladeOne.php
@@ -50,10 +50,10 @@ class PinkCrab_BladeOne extends BladeOne {
 	 * Bob the constructor.
 	 * The folder at $compiled_path is created in case it doesn't exist.
 	 *
-	 * @param string|string[] $template_path If null then it uses (caller_folder)/views
-	 * @param string          $compiled_path If null then it uses (caller_folder)/compiles
-	 * @param integer         $mode          =[BladeOne::MODE_AUTO,BladeOne::MODE_DEBUG,BladeOne::MODE_FAST,BladeOne::MODE_SLOW][$i]
-	 * @param integer         $comment_mode  =[BladeOne::COMMENT_PHP,BladeOne::COMMENT_RAW,BladeOne::COMMENT_NONE][$i]
+	 * @param string  $template_path If null then it uses (caller_folder)/views
+	 * @param string  $compiled_path If null then it uses (caller_folder)/compiles
+	 * @param integer $mode          =[BladeOne::MODE_AUTO,BladeOne::MODE_DEBUG,BladeOne::MODE_FAST,BladeOne::MODE_SLOW][$i]
+	 * @param integer $comment_mode  =[BladeOne::COMMENT_PHP,BladeOne::COMMENT_RAW,BladeOne::COMMENT_NONE][$i]
 	 */
 	public function __construct( $template_path = null, $compiled_path = null, $mode = 0, $comment_mode = 0 ) {
 		parent::__construct( $template_path, $compiled_path, $mode, $comment_mode );


### PR DESCRIPTION
This pull request includes several updates across multiple files to improve dependencies, add new commands, and refine type annotations. The most important changes include updates to the `composer.json` dependencies, addition of a new script command, adjustments to `phpstan.neon.dist` parameters, and modifications to type annotations in various classes.

### Dependency Updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L29-R45): Updated several dependencies to their latest versions, including `php-stubs/wordpress-stubs`, `roots/wordpress`, `wp-phpunit/wp-phpunit`, `dealerdirect/phpcodesniffer-composer-installer`, `wp-coding-standards/wpcs`, and `symfony/var-dumper`. Also updated `pinkcrab/perique-framework-core` to version `2.1.*`.

### New Script Command:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R54): Added a new script command `format` to run `phpcbf` for code formatting.

### Configuration Adjustments:

* [`phpstan.neon.dist`](diffhunk://#diff-6f19df6a6307a48db0940e6897591fb08776d2db8a6134737aa708defdb5c92dR7): Added the `reportUnmatchedIgnoredErrors` parameter and set it to `false` to suppress warnings about unmatched ignored errors.

### Type Annotation Refinements:

* [`src/BladeOne.php`](diffhunk://#diff-33203c3f393e648bd3ea82bff135bbf0d0a64115518145410f1c204678728437L138-R138): Changed the method call from `$config->path('view')` to `$config->view_path()` for better clarity and consistency.
* `src/BladeOne_Engine.php` and `src/PinkCrab_BladeOne.php`: Refined type annotations for `$template_path` to specify it as a `string` instead of `string|array<mixed>`. [[1]](diffhunk://#diff-f4a42325d4d848a58d135925a2c647e6e9cdbfc6434130f80db852afff4c8db8L69-R69) [[2]](diffhunk://#diff-bb762da3cbf07d055d3c0870f185a7440ad3f86af9b7e00bfe39bb9d236f29d0L53-R53)